### PR TITLE
Initialize kube-scheduler's logs options

### DIFF
--- a/cmd/cluster-capacity/app/server.go
+++ b/cmd/cluster-capacity/app/server.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	aflag "k8s.io/component-base/cli/flag"
 	configv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	"k8s.io/component-base/logs"
 	kubeschedulerconfigv1beta1 "k8s.io/kube-scheduler/config/v1beta1"
 	schedconfig "k8s.io/kubernetes/cmd/kube-scheduler/app/config"
 	schedoptions "k8s.io/kubernetes/cmd/kube-scheduler/app/options"
@@ -125,6 +126,7 @@ func Run(opt *options.ClusterCapacityOptions) error {
 	opts := &schedoptions.Options{
 		ComponentConfig: kcfg,
 		ConfigFile:      conf.Options.DefaultSchedulerConfigFile,
+		Logs:            logs.NewOptions(),
 	}
 
 	cc, err := framework.InitKubeSchedulerConfiguration(opts)


### PR DESCRIPTION
If not set, the following panic occurs:
```
./cluster-capacity --kubeconfig ~/.kube/config  --podspec examples/pod.yaml
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x16daa79]

goroutine 1 [running]:
sigs.k8s.io/cluster-capacity/vendor/k8s.io/component-base/logs.(*Options).Get(...)
/go/src/sigs.k8s.io/cluster-capacity/cmd/hypercc/main.go:42 +0x2f
```