### PR TITLE
test-e2e: just run the binary with the default example

### DIFF
--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -32,3 +32,10 @@ fi
 
 PRJ_PREFIX="sigs.k8s.io/cluster-capacity"
 go test ${PRJ_PREFIX}/test/e2e/ -v
+
+# Just test the binary works with the default example pod spec
+# See https://github.com/kubernetes-sigs/cluster-capacity/pull/127 for more detail
+go build -o hypercc sigs.k8s.io/cluster-capacity/cmd/hypercc
+ln -sf hypercc cluster-capacity
+
+./cluster-capacity --kubeconfig ~/.kube/config  --podspec examples/pod.yaml --verbose


### PR DESCRIPTION
To test the binary works over the default example without a panic.
See https://github.com/kubernetes-sigs/cluster-capacity/pull/127.