### PR TITLE
Set GO111MODULE=auto to build cc with go1.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 build:
-	go build -o hypercc sigs.k8s.io/cluster-capacity/cmd/hypercc
+	GO111MODULE=auto go build -o hypercc sigs.k8s.io/cluster-capacity/cmd/hypercc
 	ln -sf hypercc cluster-capacity
 	ln -sf hypercc genpod
 

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -21,6 +21,6 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${SCRIPT_ROOT}/hack/lib/init.sh"
 
-go test \
+GO111MODULE=auto go test \
   sigs.k8s.io/cluster-capacity/cmd/... \
   sigs.k8s.io/cluster-capacity/pkg/...

--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -31,11 +31,11 @@ if [ -n "$KIND_E2E" ]; then
 fi
 
 PRJ_PREFIX="sigs.k8s.io/cluster-capacity"
-go test ${PRJ_PREFIX}/test/e2e/ -v
+GO111MODULE=auto go test ${PRJ_PREFIX}/test/e2e/ -v
 
 # Just test the binary works with the default example pod spec
 # See https://github.com/kubernetes-sigs/cluster-capacity/pull/127 for more detail
-go build -o hypercc sigs.k8s.io/cluster-capacity/cmd/hypercc
+GO111MODULE=auto go build -o hypercc sigs.k8s.io/cluster-capacity/cmd/hypercc
 ln -sf hypercc cluster-capacity
 
 ./cluster-capacity --kubeconfig ~/.kube/config  --podspec examples/pod.yaml --verbose


### PR DESCRIPTION
The project still imports code from kubernetes/kubernetes repository
which is go module less.

https://golang.org/doc/go1.16#go-command