### PR TITLE
cleanup: remove ioutil for new go version

### DIFF
--- a/cmd/cluster-capacity/app/server.go
+++ b/cmd/cluster-capacity/app/server.go
@@ -19,7 +19,6 @@ package app
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/lithammer/dedent"
@@ -177,7 +176,7 @@ func runSimulator(s *options.ClusterCapacityConfig, kubeSchedulerConfig *schedco
 }
 
 func loadConfigFromFile(file string) (*kubeschedulerconfig.KubeSchedulerConfiguration, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The io/ioutil package has been deprecated from go 1.16:https://go.dev/doc/go1.16#ioutil

/kind cleanup