### PR TITLE
Increase channel size

### DIFF
--- a/pkg/framework/simulator.go
+++ b/pkg/framework/simulator.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
@@ -103,6 +104,7 @@ func newPodInformer(cs externalclientset.Interface, resyncPeriod time.Duration) 
 // The analysis is completely independent of apiserver so no need
 // for kubeconfig nor for apiserver url
 func New(kubeSchedulerConfig *schedconfig.CompletedConfig, kubeConfig *restclient.Config, simulatedPod *v1.Pod, maxPods int, excludeNodes []string) (*ClusterCapacity, error) {
+	watch.DefaultChanSize = 10000
 	client := fakeclientset.NewSimpleClientset()
 	sharedInformerFactory := informers.NewSharedInformerFactory(client, 0)
 	sharedInformerFactory.InformerFor(&v1.Pod{}, newPodInformer)


### PR DESCRIPTION
An internal case user has reached the maximum channel size intermittently and with this PR I am increasing it considerably to avoid that. 

```
cluster-capacity --kubeconfig kd --podspec md --verbose
panic: channel full

goroutine 1 [running]:
k8s.io/apimachinery/pkg/watch.(*RaceFreeFakeWatcher).Add(0xc001d9d680?, {0x2217f40?, 0xc001d9db00?})
	/go/src/sigs.k8s.io/cluster-capacity/vendor/k8s.io/apimachinery/pkg/watch/watch.go:218 +0x153
k8s.io/client-go/testing.(*tracker).add(0xc000181810, {{0x1f20fd5, 0x4}, {0x1f2044f, 0x2}, {0x1f2a706, 0xb}}, {0x2217f40, 0xc001d9cd80}, {0xc000e313f8, ...}, ...)
	/go/src/sigs.k8s.io/cluster-capacity/vendor/k8s.io/client-go/testing/fixture.go:431 +0xded
k8s.io/client-go/testing.(*tracker).Create(0xc000181810?, {{0x1f20fd5, 0x4}, {0x1f2044f, 0x2}, {0x1f2a706, 0xb}}, {0x2217f40?, 0xc001d9cd80?}, {0xc000e313f8, ...})
	/go/src/sigs.k8s.io/cluster-capacity/vendor/k8s.io/client-go/testing/fixture.go:356 +0x85
k8s.io/client-go/testing.ObjectReaction.func1({0x2234650, 0xc00066e780})
	/go/src/sigs.k8s.io/cluster-capacity/vendor/k8s.io/client-go/testing/fixture.go:103 +0x283
k8s.io/client-go/testing.(*SimpleReactor).React(0xc00087c930?, {0x2234650?, 0xc00066e780?})
	/go/src/sigs.k8s.io/cluster-capacity/vendor/k8s.io/client-go/testing/fixture.go:530 +0x2d
k8s.io/client-go/testing.(*Fake).Invokes(0xc0000fc580, {0x2234650, 0xc00066e680}, {0x2217f40, 0xc001d9c900})
	/go/src/sigs.k8s.io/cluster-capacity/vendor/k8s.io/client-go/testing/fake.go:145 +0x288
k8s.io/client-go/kubernetes/typed/apps/v1/fake.(*FakeReplicaSets).Create(0xc001d03ec0, {0x0?, 0x0?}, 0x0?, {{{0x0, 0x0}, {0x0, 0x0}}, {0x0, 0x0, ...}, ...})
	/go/src/sigs.k8s.io/cluster-capacity/vendor/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_replicaset.go:91 +0x14d
sigs.k8s.io/cluster-capacity/pkg/framework.(*ClusterCapacity).SyncWithClient(0xc0002faa20, {0x224a8e8, 0xc000148900})
	/go/src/sigs.k8s.io/cluster-capacity/pkg/framework/simulator.go:261 +0xdcd
sigs.k8s.io/cluster-capacity/cmd/cluster-capacity/app.runSimulator(0xc00081fcd8, 0x3b?)
	/go/src/sigs.k8s.io/cluster-capacity/cmd/cluster-capacity/app/server.go:165 +0x65
sigs.k8s.io/cluster-capacity/cmd/cluster-capacity/app.Run(0xc0005dbf80?)
	/go/src/sigs.k8s.io/cluster-capacity/cmd/cluster-capacity/app/server.go:149 +0x278
sigs.k8s.io/cluster-capacity/cmd/cluster-capacity/app.NewClusterCapacityCommand.func1(0xc000373900?, {0x1f211a5?, 0x5?, 0x5?})
	/go/src/sigs.k8s.io/cluster-capacity/cmd/cluster-capacity/app/server.go:67 +0xc6
github.com/spf13/cobra.(*Command).execute(0xc000373900, {0xc0001a4130, 0x5, 0x5})
	/go/src/sigs.k8s.io/cluster-capacity/vendor/github.com/spf13/cobra/command.go:860 +0x663
github.com/spf13/cobra.(*Command).ExecuteC(0xc000373900)
	/go/src/sigs.k8s.io/cluster-capacity/vendor/github.com/spf13/cobra/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/sigs.k8s.io/cluster-capacity/vendor/github.com/spf13/cobra/command.go:902
main.cmdExecute(0x1b24420?)
	/go/src/sigs.k8s.io/cluster-capacity/cmd/hypercc/main.go:42 +0x19
main.main()
	/go/src/sigs.k8s.io/cluster-capacity/cmd/hypercc/main.go:33 +0x9f
```