### PR TITLE
fix: Dockerfile CMD syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ MAINTAINER Avesh Agarwal <avagarwa@redhat.com>
 COPY hypercc /bin/hypercc
 RUN ln -sf /bin/hypercc /bin/cluster-capacity
 RUN ln -sf /bin/hypercc /bin/genpod
-CMD ["/bin/cluster-capacity --help"]
+CMD ["/bin/cluster-capacity", "--help"]


### PR DESCRIPTION
Original syntax will result in:

```bash
$ make image
docker build -t cluster-capacity .
Sending build context to Docker daemon  161.9MB
Step 1/6 : FROM golang:latest
...
Successfully built dae542bae31f
Successfully tagged cluster-capacity:latest

$ docker run --rm cluster-capacity:latest
docker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "/bin/cluster-capacity --help": stat /bin/cluster-capacity --help: no such file or directory: unknown.
```