### PR TITLE
e2e: bump kind to v0.27.0

### DIFF
--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -26,9 +26,9 @@ KIND_E2E=${KIND_E2E:-}
 if [ -n "$KIND_E2E" ]; then
     # If we did not set SKIP_INSTALL
     if [ -z "$SKIP_INSTALL" ]; then
-        K8S_VERSION=${KUBERNETES_VERSION:-v1.30.0}
+        K8S_VERSION=${KUBERNETES_VERSION:-v1.33.0}
         curl -Lo kubectl https://dl.k8s.io/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/
-        wget https://github.com/kubernetes-sigs/kind/releases/download/v0.23.0/kind-linux-amd64
+        wget https://github.com/kubernetes-sigs/kind/releases/download/v0.27.0/kind-linux-amd64
         chmod +x kind-linux-amd64
         mv kind-linux-amd64 kind
         export PATH=$PATH:$PWD


### PR DESCRIPTION
To address:
```
+ kind load docker-image registry.k8s.io/pause
Image: "registry.k8s.io/pause" with ID "sha256:350b164e7ae1dcddeffadd65c76226c9b6dc5553f5179153fb0e36b78f2a5e06" not yet present on node "kind-worker", loading...
Image: "registry.k8s.io/pause" with ID "sha256:350b164e7ae1dcddeffadd65c76226c9b6dc5553f5179153fb0e36b78f2a5e06" not yet present on node "kind-worker2", loading...
Image: "registry.k8s.io/pause" with ID "sha256:350b164e7ae1dcddeffadd65c76226c9b6dc5553f5179153fb0e36b78f2a5e06" not yet present on node "kind-control-plane", loading...
ERROR: failed to detect containerd snapshotter
```