### PR TITLE
fix: Return error when postBindHook fails

### DIFF
--- a/pkg/framework/plugins/clustercapacitybinder/plugin.go
+++ b/pkg/framework/plugins/clustercapacitybinder/plugin.go
@@ -45,7 +45,7 @@ func (b *ClusterCapacityBinder) Bind(ctx context.Context, state *framework.Cycle
 	}
 
 	if err := b.postBindHook(updatedPod); err != nil {
-		framework.NewStatus(framework.Error, fmt.Sprintf("Invoking postBindHook gives an error: %v", err))
+		return framework.NewStatus(framework.Error, fmt.Sprintf("Invoking postBindHook gives an error: %v", err))
 	}
 
 	return nil


### PR DESCRIPTION
The original code obviously intended to return the error but forgot the keyword.

@ingvagabund
