### PR TITLE
Fix typo: occured -> occurred in test error messages

### DIFF
--- a/pkg/framework/simulator_test.go
+++ b/pkg/framework/simulator_test.go
@@ -249,7 +249,7 @@ func TestPrediction(t *testing.T) {
 			// time.Sleep(5 * time.Second)
 			//4. check expected number of pods is scheduled and reflected in the resource storage
 			if cc.Report().Status.FailReason.FailType != test.failType {
-				t.Errorf("Unexpected stop reason occured: %v, expecting: %v", cc.Report().Status.FailReason.FailType, test.failType)
+				t.Errorf("Unexpected stop reason occurred: %v, expecting: %v", cc.Report().Status.FailReason.FailType, test.failType)
 			}
 
 			cc.Close()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -169,6 +169,6 @@ func TestLimitReached(t *testing.T) {
 	t.Logf("Stop reason: %v\n", cc.Report().Status.FailReason)
 
 	if cc.Report().Status.FailReason.FailType != failType {
-		t.Fatalf("Unexpected stop reason occured: %v, expecting: %v", cc.Report().Status.FailReason.FailType, failType)
+		t.Fatalf("Unexpected stop reason occurred: %v, expecting: %v", cc.Report().Status.FailReason.FailType, failType)
 	}
 }


### PR DESCRIPTION
Corrects the misspelling 'occured' to 'occurred' in two test error/fatal messages.